### PR TITLE
Fix distance check bug in `are_planes_parallel_and_close()`

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -279,7 +279,7 @@ def are_planes_parallel_and_close(
 
     return (
         np.linalg.norm(np.cross(n1, n2)) / (n1_length * n2_length) < parallel_tolerance
-        and np.dot(np.subtract(q1, p1), n1) / n1_length < dist_tolerance
+        and np.abs(np.dot(np.subtract(q1, p1), n1)) / n1_length < dist_tolerance
     )
 
 


### PR DESCRIPTION
Fixes #132.

Simple test case:

```Python
import math
from eval import are_planes_parallel_and_close
import numpy as np

corners_1 = np.array([
    [0.0, 0.0, 0.0],
    [1.0, 0.0, 0.0],
    [1.0, 0.0, 1.0],
    [0.0, 0.0, 1.0],
])

corners_2 = np.array([
    [0.0, 1.0, 0.0],
    [1.0, 1.0, 0.0],
    [1.0, 1.0, 1.0],
    [0.0, 1.0, 1.0],
])

parallel_tolerance: float = math.sin(math.radians(5))
dist_tolerance: float = 0.2

assert not are_planes_parallel_and_close(corners_1, corners_2, parallel_tolerance, dist_tolerance)
```